### PR TITLE
Simplification of older MVL code, unnecessary numpy manipulations

### DIFF
--- a/audio_input_thread.py
+++ b/audio_input_thread.py
@@ -1,3 +1,4 @@
+import math
 import threading
 import queue
 
@@ -12,7 +13,6 @@ class audio_input(threading.Thread):
         q_in: queue.Queue,
         sample_rate: int,
         input_device_idx: int,
-        NUM_CHUNKS: int,
         MAX_INFER_SAMPLES_VC: int,
         HDW_FRAMES_PER_BUFFER: int,
         stop_queue: queue.Queue,
@@ -25,14 +25,16 @@ class audio_input(threading.Thread):
         self.q_in = q_in
         self.sample_rate = sample_rate
         self.input_device_idx = input_device_idx
-        self.NUM_CHUNKS = NUM_CHUNKS
         self.MAX_INFER_SAMPLES_VC = MAX_INFER_SAMPLES_VC
         self.HDW_FRAMES_PER_BUFFER = HDW_FRAMES_PER_BUFFER
         self.stop_queue = stop_queue
         
+        self.NUM_CHUNKS = math.ceil(MAX_INFER_SAMPLES_VC / HDW_FRAMES_PER_BUFFER)
+        print(f"NUM_CHUNKS: {self.NUM_CHUNKS}")
+        
         # create rolling deque for io_stream data packets
-        self.data = deque(maxlen=NUM_CHUNKS)
-        for _ in range(NUM_CHUNKS):
+        self.data = deque(maxlen=self.NUM_CHUNKS)
+        for _ in range(self.NUM_CHUNKS):
             in_data = np.zeros(HDW_FRAMES_PER_BUFFER, dtype=np.float32)
             self.data.append(in_data)        
         
@@ -56,14 +58,14 @@ class audio_input(threading.Thread):
                     # This is blocking until enough frames are received. We're silently ignoring overflows.
                     wav_bytes = io_stream.read(self.HDW_FRAMES_PER_BUFFER, False)
                  
-                    # Look into why we're pushing through NumPy. To convert to Float32? To allow for the following splice?
+                    # The model (and librosa) ultimately wants an ndarray. Convert it and ensure it's float32.
                     in_data_np = np.frombuffer(wav_bytes, dtype=np.float32)
 
                     # Data is a rolling queue of chunks, totalling about 1.48s of audio. This is to give the model more to work with in terms of infering tone, inflection, etc.
                     self.data.append(in_data_np)
                     
-                    # Push into queue for the model.
-                    self.q_in.put_nowait(np.array(self.data).flatten().astype(np.float32)[-self.MAX_INFER_SAMPLES_VC:].tobytes())
+                    # Push into queue for the model. We splice because it's possible that deque has 1 more chunk than MAX_INFER_SAMPLES_VC wants.
+                    self.q_in.put_nowait(np.array(self.data).flatten()[-self.MAX_INFER_SAMPLES_VC:])
                 except queue.Empty:
                     pass
         except KeyboardInterrupt:

--- a/audio_output_thread.py
+++ b/audio_output_thread.py
@@ -1,7 +1,6 @@
 import threading
 import queue
 
-import numpy as np
 import pyaudio
 
 class audio_output(threading.Thread):
@@ -10,7 +9,6 @@ class audio_output(threading.Thread):
         q_out: queue.Queue,
         sample_rate: int,
         output_device_idx: int,
-        MAX_INFER_SAMPLES_VC: int,
         HDW_FRAMES_PER_BUFFER: int,
         stop_queue: queue.Queue,
         args=(),
@@ -22,7 +20,6 @@ class audio_output(threading.Thread):
         self.q_out = q_out
         self.sample_rate = sample_rate
         self.output_device_idx = output_device_idx
-        self.MAX_INFER_SAMPLES_VC = MAX_INFER_SAMPLES_VC
         self.HDW_FRAMES_PER_BUFFER = HDW_FRAMES_PER_BUFFER
         self.stop_queue = stop_queue
         

--- a/conversion_thread.py
+++ b/conversion_thread.py
@@ -1,9 +1,5 @@
 import threading
 import queue
-from datetime import datetime
-from typing import Callable, Optional
-
-import numpy as np
 
 from voice_conversion import StudioModelConversionPipeline, ConversionPipeline
 
@@ -30,11 +26,12 @@ class Conversion(threading.Thread):
             while self.stop_queue.empty():
                 try:
                     # Wait on PyAudio input. We have a timeout so if the model never gives us anything, we'll break the block and loop around to check stop_queue
-                    wav_bytes = self.q_in.get(timeout=5)
+                    wav = self.q_in.get(timeout=5)
 
-                    wav = np.frombuffer(wav_bytes, dtype=np.float32)
+                    # Infer!
                     out = self.voice_conversion.run(wav, self.HDW_FRAMES_PER_BUFFER)
 
+                    # Queue it up for the audio output thread.
                     self.q_out.put_nowait(out.tobytes())
                 except queue.Empty:
                     pass

--- a/inference_rt.py
+++ b/inference_rt.py
@@ -53,18 +53,16 @@ class InferenceRt(threading.Thread):
         print(f"MAX_INFER_SAMPLES_VC: {MAX_INFER_SAMPLES_VC}")
     
         HDW_FRAMES_PER_BUFFER = math.ceil(sample_rate * callback_latency_ms / 1000)
-        NUM_CHUNKS = math.ceil(MAX_INFER_SAMPLES_VC / HDW_FRAMES_PER_BUFFER)
         print(f"HDW_FRAMES_PER_BUFFER: {HDW_FRAMES_PER_BUFFER}")
-        print(f"NUM_CHUNKS: {NUM_CHUNKS}")
 
         # init
         q_in, q_out = queue.Queue(), queue.Queue()
 
         # run pipeline
         try:
-            audio_input_thread = audio_input(self.__p, q_in, sample_rate, input_device_idx, NUM_CHUNKS, MAX_INFER_SAMPLES_VC, HDW_FRAMES_PER_BUFFER, queue.Queue())
+            audio_input_thread = audio_input(self.__p, q_in, sample_rate, input_device_idx, MAX_INFER_SAMPLES_VC, HDW_FRAMES_PER_BUFFER, queue.Queue())
             conversion_thread = Conversion(q_in, q_out, voice_conversion, HDW_FRAMES_PER_BUFFER, queue.Queue(), args=())
-            audio_output_thread = audio_output(self.__p, q_out, sample_rate, output_device_idx, MAX_INFER_SAMPLES_VC, HDW_FRAMES_PER_BUFFER, queue.Queue())
+            audio_output_thread = audio_output(self.__p, q_out, sample_rate, output_device_idx, HDW_FRAMES_PER_BUFFER, queue.Queue())
             
             audio_input_thread.start()
             conversion_thread.start()      


### PR DESCRIPTION
Clean up some unnecessary back and forth numpy data manipulations. We were converting bytes to ndarray, then converting it back to bytes, then BACK to ndarray.